### PR TITLE
Fix seed.js file to use correct MongoDB client API

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -33,7 +33,7 @@ MongoClient.connect(config.mongodb.connectionUrl, function(err, result) {
 
   console.log('Connected to server.');
 
-  db = result;
+  db = result.db();
 
   for (collectionName of ['challenges']) {
     promiseArray.push(doCollection(collectionName));
@@ -47,7 +47,7 @@ MongoClient.connect(config.mongodb.connectionUrl, function(err, result) {
       console.log(`Server not seeded: ${e}`);
     });
 
-  db.close();
+  result.close();
 
 });
 


### PR DESCRIPTION
Current seed.js implementations uses MongoDB API for version 2.x, but package.json specifies 3.1.1 or higher version. So seeding operation results in errors. A few lines were changed, and not it is working perfectly fine.